### PR TITLE
Fix to spawn no-block system.

### DIFF
--- a/game/server/player/player.cpp
+++ b/game/server/player/player.cpp
@@ -2232,12 +2232,12 @@ pt_end:
 	//Deactivate no-collide if not near any players.
 	postthinkdbg("Check for nearby spawns and players, deactivate nocolloide");
 	//do not check for dead or spectating/noclipping players
-	if (pev->solid == SOLID_NOT && pev->deadflag == DEAD_NO && pev->movetype != MOVETYPE_NOCLIP) {
+	if (pev->solid == SOLID_TRIGGER && pev->deadflag == DEAD_NO && pev->movetype != MOVETYPE_NOCLIP) {
 
 		CBaseEntity* fEnt = NULL;
 		//initialize proximity check
 		bool hasProximity = false;
-		int proximityDistance = 124;
+		int proximityDistance = 32;
 
 		//loop through all nearby entities
 		while ( (fEnt = UTIL_FindEntityInSphere(fEnt, pev->origin, proximityDistance) ) != NULL) {
@@ -2662,7 +2662,7 @@ void CBasePlayer::Spawn(void)
 	pev->classname = MAKE_STRING("player");
 	pev->armorvalue = 0;
 	pev->takedamage = DAMAGE_AIM;
-	pev->solid = SOLID_NOT;
+	pev->solid = SOLID_TRIGGER;
 	pev->movetype = MOVETYPE_WALK;
 	pev->flags = FL_CLIENT;
 	pev->air_finished = gpGlobals->time + 12;


### PR DESCRIPTION
Players are now SOLID_TRIGGER which seems to work (tested with thornlands_north boar spawn) And the distance to turning off the spawn blocking system has been reduced to be 32 units which is barely wider than a player.

As for spells not working on no-collided players this is a limitation in the raycasting as it is designed not to hit solid_not and solid_trigger which means (most likely) engine limitation.

Music still being tested and if fixable or fixed will update in comment.

Related Issue:
#157 