### PR TITLE
Exp now prioritises the lowest or furthest back expwise substats.

### DIFF
--- a/game/server/monsters/msmonster.h
+++ b/game/server/monsters/msmonster.h
@@ -441,7 +441,7 @@ public:
 	void CounterEffect(CBaseEntity *pInflictor, int iEffect, void *pExtraData);
 	float GetBodyDist(Vector Point, float Radius);
 
-	virtual bool LearnSkill(int iStat, int iStatType, int EnemySkillLevel);
+	virtual std::tuple<bool, int> LearnSkill(int iStat, int iStatType, int EnemySkillLevel);
 	virtual bool LearnSkill(int iStat, int EnemySkillLevel) { return false; }
 
 	virtual BOOL CanSetVelocity();

--- a/game/server/player/player.h
+++ b/game/server/player/player.h
@@ -534,7 +534,7 @@ public:
 	void Storage_Send();
 	void Music_Play(songplaylist &Songs, CBaseEntity *pMusicArea);
 	void Music_Stop(CBaseEntity *pMusicArea);
-	bool LearnSkill(int iStat, int iStatType, int EnemySkillLevel);
+	std::tuple<bool, int> LearnSkill(int iStat, int iStatType, int EnemySkillLevel);
 	bool LearnSkill(int iStat, int EnemySkillLevel);
 	void SetQuest(bool SetData, msstring_ref Name, msstring_ref Data);
 	float TraceAttack(damage_t &Damage);

--- a/game/server/player/playerstats.cpp
+++ b/game/server/player/playerstats.cpp
@@ -26,7 +26,7 @@ void CBasePlayer::SetSize(int flags)
 {
 	UTIL_SetSize(pev, -(Size(flags) / 2), Size(flags) / 2);
 }
-void CBasePlayer::SendMenu(int iMenu, TCallbackMenu *cbmMenu)
+void CBasePlayer::SendMenu(int iMenu, TCallbackMenu* cbmMenu)
 {
 	switch (iMenu)
 	{
@@ -36,8 +36,8 @@ void CBasePlayer::SendMenu(int iMenu, TCallbackMenu *cbmMenu)
 		//CurrentCallbackMenu must be dynamic memory
 		if (CurrentCallbackMenu && CurrentCallbackMenu != cbmMenu)
 		{
-			TCallbackMenu *pOldMenu = CurrentCallbackMenu;
-			CBaseEntity *pOwner = GetClassPtr((CBaseEntity *)pOldMenu->pevOwner);
+			TCallbackMenu* pOldMenu = CurrentCallbackMenu;
+			CBaseEntity* pOwner = GetClassPtr((CBaseEntity*)pOldMenu->pevOwner);
 			//Let the callback function delete its own memory, then I delete the menu
 			if (pOwner && pOldMenu->m_MenuCallback)
 				(pOwner->*(pOldMenu->m_MenuCallback))(this, -1, pOldMenu);
@@ -57,11 +57,11 @@ void CBasePlayer::ParseMenu(int iMenu, int slot)
 	case MENU_USERDEFINED:
 		if (!CurrentCallbackMenu || !CurrentCallbackMenu->m_MenuCallback || !CurrentCallbackMenu->pevOwner)
 			break;
-		CBaseEntity *pOwner = GetClassPtr((CBaseEntity *)CurrentCallbackMenu->pevOwner);
+		CBaseEntity* pOwner = GetClassPtr((CBaseEntity*)CurrentCallbackMenu->pevOwner);
 		if (!pOwner)
 			break;
 
-		TCallbackMenu *pOldMenu = CurrentCallbackMenu;
+		TCallbackMenu* pOldMenu = CurrentCallbackMenu;
 		(pOwner->*(pOldMenu->m_MenuCallback))(this, slot, pOldMenu);
 		//CurrentCallbackMenu must be dynamic memory
 		if (CurrentCallbackMenu == pOldMenu)
@@ -71,75 +71,122 @@ void CBasePlayer::ParseMenu(int iMenu, int slot)
 		break;
 	}
 }
-bool CBasePlayer::LearnSkill(int iStat, int iStatType, int EnemySkillLevel)
-{
-	bool fSuccess = CMSMonster::LearnSkill(iStat, iStatType, EnemySkillLevel);
-	int iStatIdx = iStat - SKILL_FIRSTSKILL;
 
-	//Thoth DEC2008a level cap
-	if (GetSkillStat(iStatIdx, iStatType) >= CHAR_LEVEL_CAP)
-		return false;
+std::tuple<bool, int> CBasePlayer::LearnSkill(int iStat, int iStatType, int EnemySkillLevel)
+{	
+	//see if a skill leveled.
+	bool bSkillLeveled = false;
+	
+	// track remaining exp
+	int iRemainingExp = EnemySkillLevel;
 
-	msstring stat_name = SkillStatList[iStatIdx].Name;
-	bool is_spell_stat = stat_name.contains("Spell");
-	if (is_spell_stat)
-		ALERT(at_console, "Gained XP: %i in skill %s %s \n", EnemySkillLevel, SkillStatList[iStatIdx].Name, SpellTypeList[iStatType]); //Thothie returns XP gained by monsters
-	else
-		ALERT(at_console, "Gained XP: %i in skill %s %s \n", EnemySkillLevel, SkillStatList[iStatIdx].Name, SkillTypeList[iStatType]); //Thothie returns XP gained by monsters
-	if (fSuccess)
-	{
-		startdbg;
-		hudtextparms_t htp;
-		memset(&htp, 0, sizeof(hudtextparms_t));
-		htp.x = 0.02;
-		htp.y = 0.6;
-		htp.effect = 2;
-		htp.r1 = 0;
-		htp.g1 = 128;
-		htp.b1 = 0;
-		htp.r2 = 178;
-		htp.g2 = 119;
-		htp.b2 = 0;
-		htp.fadeinTime = 0.02;
-		htp.fadeoutTime = 3.0;
-		htp.holdTime = 2.0;
-		htp.fxTime = 0.6;
-		dbg("HudMessage");
-		UTIL_HudMessage(this, htp, UTIL_VarArgs("%s %s +1\n", SkillStatList[iStatIdx].Name, SkillTypeList[iStatType]));
+	while (iRemainingExp > 0) {
+		CStat* csExpStat = CMSMonster::FindStat(iStat);
+		int iFirstSubValue = csExpStat->m_SubStats[0].Value;
 
-		if (!is_spell_stat)
+		// find the best substat to give things to;
+		int iBestSubstatId = 10;
+
+		//see if anything has lower substats than the first skill in the list
+		for (int idx = 0; idx < csExpStat->m_SubStats.size(); idx++) {
+			if (csExpStat->m_SubStats[idx].Value < iFirstSubValue) {
+				iBestSubstatId = idx;
+			}
+			else if (csExpStat->m_SubStats[idx].Value == 0) {
+				iBestSubstatId = idx;
+				break;
+			}
+		}
+
+		//if we didn't find a low substat, go through the remaining exp instead
+		if (iBestSubstatId == 10) {
+			long double	ldHighestExpRemaining = 0;
+
+			for (int idx = 0; idx < csExpStat->m_SubStats.size(); idx++) {
+				long double ldCurrentExpRemaining = abs(GetExpNeeded(csExpStat->m_SubStats[idx].Value) - csExpStat->m_SubStats[idx].Exp);
+				
+				if (ldCurrentExpRemaining > ldHighestExpRemaining) {
+					ldHighestExpRemaining = ldCurrentExpRemaining;
+					iBestSubstatId = idx;
+				}
+
+			}
+		}
+
+		//run learnskill
+		std::tuple<bool, int> tbiSuccess = CMSMonster::LearnSkill(iStat, iBestSubstatId, iRemainingExp);
+		int iStatIdx = iStat - SKILL_FIRSTSKILL;
+
+		//Thoth DEC2008a level cap
+		if (GetSkillStat(iStatIdx, iStatType) >= CHAR_LEVEL_CAP)
+			return std::make_tuple(false, 0);
+
+		msstring stat_name = SkillStatList[iStatIdx].Name;
+		bool is_spell_stat = stat_name.contains("Spell");
+		if (is_spell_stat)
+			ALERT(at_console, "Gained XP: %i in skill %s %s \n", EnemySkillLevel, SkillStatList[iStatIdx].Name, SpellTypeList[iStatType]); //Thothie returns XP gained by monsters
+		else
+			ALERT(at_console, "Gained XP: %i in skill %s %s \n", EnemySkillLevel, SkillStatList[iStatIdx].Name, SkillTypeList[iStatType]); //Thothie returns XP gained by monsters
+		if (std::get<0>(tbiSuccess))
 		{
-			SendInfoMsg("You become more adept at %s.\n", SkillStatList[iStatIdx].Name);
+			startdbg;
+			hudtextparms_t htp;
+			memset(&htp, 0, sizeof(hudtextparms_t));
+			htp.x = 0.02;
+			htp.y = 0.6;
+			htp.effect = 2;
+			htp.r1 = 0;
+			htp.g1 = 128;
+			htp.b1 = 0;
+			htp.r2 = 178;
+			htp.g2 = 119;
+			htp.b2 = 0;
+			htp.fadeinTime = 0.02;
+			htp.fadeoutTime = 3.0;
+			htp.holdTime = 2.0;
+			htp.fxTime = 0.6;
+			dbg("HudMessage");
 			UTIL_HudMessage(this, htp, UTIL_VarArgs("%s %s +1\n", SkillStatList[iStatIdx].Name, SkillTypeList[iStatType]));
-		}
-		else
-		{
-			SendInfoMsg("You become more adept at %s.\n", SkillStatList[iStatIdx]);
-			UTIL_HudMessage(this, htp, UTIL_VarArgs("%s %s +1\n", SkillStatList[iStatIdx].Name, SpellTypeList[iStatType]));
+
+			if (!is_spell_stat)
+			{
+				SendInfoMsg("You become more adept at %s.\n", SkillStatList[iStatIdx].Name);
+				UTIL_HudMessage(this, htp, UTIL_VarArgs("%s %s +1\n", SkillStatList[iStatIdx].Name, SkillTypeList[iStatType]));
+			}
+			else
+			{
+				SendInfoMsg("You become more adept at %s.\n", SkillStatList[iStatIdx]);
+				UTIL_HudMessage(this, htp, UTIL_VarArgs("%s %s +1\n", SkillStatList[iStatIdx].Name, SpellTypeList[iStatType]));
+			}
+
+			dbg("game_learnskill");
+			msstringlist Params;
+			Params.add(SkillStatList[iStatIdx].Name);
+			if (!is_spell_stat)
+				Params.add(SkillTypeList[iStatType]);
+			else
+				Params.add(SpellTypeList[iStatType]);
+			Params.add(UTIL_VarArgs("%i", GetSkillStat(iStatIdx, iStatType)));
+			CallScriptEvent("game_learnskill", &Params);
+			enddbg;
 		}
 
-		dbg("game_learnskill");
-		msstringlist Params;
-		Params.add(SkillStatList[iStatIdx].Name);
-		if (!is_spell_stat)
-			Params.add(SkillTypeList[iStatType]);
-		else
-			Params.add(SpellTypeList[iStatType]);
-		Params.add(UTIL_VarArgs("%i", GetSkillStat(iStatIdx, iStatType)));
-		CallScriptEvent("game_learnskill", &Params);
-		enddbg;
+		bSkillLeveled = true;
+
+		iRemainingExp = std::get<1>(tbiSuccess);
 	}
-	return fSuccess;
+
+	return std::make_tuple(bSkillLeveled, 0);
 }
 bool CBasePlayer::LearnSkill(int iStat, int EnemySkillLevel)
 {
 	//Exp is added to a random property of the skill
-	CStat *pStat = FindStat(iStat);
+	CStat* pStat = FindStat(iStat);
 	if (!pStat)
 		return false;
 
 	int iSubStat = RANDOM_LONG(0, (pStat->m_SubStats.size() - 1));
 	//SendInfoMsg( "You gain %d XP", EnemySkillLevel ); //thothie - XP report - no workie
 
-	return LearnSkill(iStat, iSubStat, EnemySkillLevel);
+	return std::get<0>(LearnSkill(iStat, iSubStat, EnemySkillLevel));
 }


### PR DESCRIPTION
EXP is now divied up to it's source skill, should fix up any inequalities in leveling substats and set up for if we want to hide substats and consolidate them into one exp bar.

Related Issues:
#117 