### PR TITLE
ID Hud Improvements

### DIFF
--- a/game/client/clientlibrary.cpp
+++ b/game/client/clientlibrary.cpp
@@ -72,7 +72,7 @@ void CClientLibrary::HUDInit()
 	CVAR_CREATE("ms_sprint_toggle", "1", FCVAR_ARCHIVE);
 	CVAR_CREATE("ms_sprint_doubletap", "1", FCVAR_ARCHIVE);
 	CVAR_CREATE("msui_id_offsetx", "100", FCVAR_ARCHIVE);
-	CVAR_CREATE("msui_id_offsety", "100", FCVAR_ARCHIVE);
+	CVAR_CREATE("msui_id_offsety", "-30", FCVAR_ARCHIVE);
 	CVAR_CREATE("msui_id_background", "0", FCVAR_ARCHIVE);
 
 	RichPresenceInitialize();

--- a/game/client/clientlibrary.cpp
+++ b/game/client/clientlibrary.cpp
@@ -73,6 +73,7 @@ void CClientLibrary::HUDInit()
 	CVAR_CREATE("ms_sprint_doubletap", "1", FCVAR_ARCHIVE);
 	CVAR_CREATE("msui_id_offsetx", "100", FCVAR_ARCHIVE);
 	CVAR_CREATE("msui_id_offsety", "100", FCVAR_ARCHIVE);
+	CVAR_CREATE("msui_id_background", "0", FCVAR_ARCHIVE);
 
 	RichPresenceInitialize();
 }

--- a/game/client/clientlibrary.cpp
+++ b/game/client/clientlibrary.cpp
@@ -71,6 +71,8 @@ void CClientLibrary::HUDInit()
 	CVAR_CREATE("ms_sprint_verbose", "2", FCVAR_ARCHIVE); // 0 for no messages , 1 for only warnings , 2 for everything
 	CVAR_CREATE("ms_sprint_toggle", "1", FCVAR_ARCHIVE);
 	CVAR_CREATE("ms_sprint_doubletap", "1", FCVAR_ARCHIVE);
+	CVAR_CREATE("msui_id_offsetx", "100", FCVAR_ARCHIVE);
+	CVAR_CREATE("msui_id_offsety", "100", FCVAR_ARCHIVE);
 
 	RichPresenceInitialize();
 }

--- a/game/client/ui/ms/vgui_hud.cpp
+++ b/game/client/ui/ms/vgui_hud.cpp
@@ -95,46 +95,46 @@ class CHUDPanel : public VGUI_MainPanel
 {
 public:
 	//Voting ----------------------------
-	VGUI_VoteInfo *m_VoteInfo;
+	VGUI_VoteInfo* m_VoteInfo;
 
 	//Health & Mana ---------------------
-	VGUI_Health *m_Health;
+	VGUI_Health* m_Health;
 
 	//Status Icons ----------------------
-	VGUI_Status *m_Status; //Drigien MAY2008
+	VGUI_Status* m_Status; //Drigien MAY2008
 
 	//Text Windows ----------------------
-	mslist<class CInfoWindow *> InfoWindows;
-	mslist<class CInfoWindow *> HelpWindows;
+	mslist<class CInfoWindow*> InfoWindows;
+	mslist<class CInfoWindow*> HelpWindows;
 	void AddInfoWin(msstring_ref Title, msstring_ref Text);
 	void AddHelpWin(msstring_ref Title, msstring_ref Text);
-	void UpdateInfoWindows(mslist<CInfoWindow *> &Windows);
-	void RemoveInfoWindow(mslist<CInfoWindow *> &Windows, int idx);
+	void UpdateInfoWindows(mslist<CInfoWindow*>& Windows);
+	void RemoveInfoWindow(mslist<CInfoWindow*>& Windows, int idx);
 
 	//Event Console ---------------------
-	mslist<VGUI_EventConsole *> m_Consoles;
+	mslist<VGUI_EventConsole*> m_Consoles;
 	void PrintEvent(Color color, msstring_ref Text);
 	void PrintSayText(Color color, msstring_ref Text);
 	void StepInput(hudscroll_e ScrollCmd);
-	VGUI_EventConsole *m_ActiveConsole;
+	VGUI_EventConsole* m_ActiveConsole;
 
 	//Start Say Text Panel --------------
-	VGUI_SendTextPanel *m_StartSayText;
-	bool KeyInput(int down, int keynum, const char *pszCurrentBinding);
+	VGUI_SendTextPanel* m_StartSayText;
+	bool KeyInput(int down, int keynum, const char* pszCurrentBinding);
 
 	//ID Panel --------------------------
-	VGUI_ID *m_ID;
+	VGUI_ID* m_ID;
 	//-----------------------------------
 
 	//Debug Text
-	MSLabel *m_DebugText;
+	MSLabel* m_DebugText;
 	//-----------------------------------
 
 	//QuickSlot Text
-	VGUI_QuickSlot *m_QuickSlot;
+	VGUI_QuickSlot* m_QuickSlot;
 	//-----------------------------------
 
-	CHUDPanel(Panel *pParent);
+	CHUDPanel(Panel* pParent);
 
 	virtual bool SlotInput(int iSlot);
 	virtual void Open(void);
@@ -143,15 +143,15 @@ public:
 	//virtual void SetActiveInfo( int iInput );
 	virtual void Initialize(void);
 
-	mslist<IHUD_Interface *> m_HUDElements;
+	mslist<IHUD_Interface*> m_HUDElements;
 };
 
-VGUI_MainPanel *CreateHUDPanel(Panel *pParent) { return new CHUDPanel(pParent); }
+VGUI_MainPanel* CreateHUDPanel(Panel* pParent) { return new CHUDPanel(pParent); }
 
 // Create new Info window
 void CHUDPanel::AddInfoWin(msstring_ref Title, msstring_ref Text)
 {
-	CInfoWindow &NewInfoWin = *new CInfoWindow(Title, Text, INFOWIN_DISPLAY_X, INFOWIN_DISPLAY_Y, this);
+	CInfoWindow& NewInfoWin = *new CInfoWindow(Title, Text, INFOWIN_DISPLAY_X, INFOWIN_DISPLAY_Y, this);
 
 	NewInfoWin.m_TimeDisplayed = gpGlobals->time;
 	NewInfoWin.m_Duration = INFOWIN_DURATION;
@@ -173,11 +173,11 @@ void CHUDPanel::AddHelpWin(msstring_ref Title, msstring_ref Text)
 	for (int i = 0; i < size; i++)
 	{
 		if (Text[i] == '|')
-			((char *)Text)[i] = '\n';
+			((char*)Text)[i] = '\n';
 	}
 
 	//CInfoWindow &NewInfoWin = *new CInfoWindow( Title, Text, INFOWIN_HELP_DISPLAY_X, INFOWIN_HELP_DISPLAY_Y, this );
-	CInfoWindow &NewInfoWin = *new CInfoWindow(Title, Text, INFOWIN_HELP_DISPLAY_X, YRES(10), this); //MAR2008a - moving helptip window not to overlap eventhud
+	CInfoWindow& NewInfoWin = *new CInfoWindow(Title, Text, INFOWIN_HELP_DISPLAY_X, YRES(10), this); //MAR2008a - moving helptip window not to overlap eventhud
 
 	NewInfoWin.Resize();
 	//NewInfoWin.setPos( XRES(640) - NewInfoWin.getWide()- XRES(60), INFOWIN_HELP_DISPLAY_Y );
@@ -202,7 +202,7 @@ void CHUDPanel::PrintSayText(Color color, msstring_ref Text)
 
 // VGUI HUD Creation
 // -----------------
-CHUDPanel::CHUDPanel(Panel *pParent) : VGUI_MainPanel(0, 0, 0, ScreenWidth, ScreenHeight)
+CHUDPanel::CHUDPanel(Panel* pParent) : VGUI_MainPanel(0, 0, 0, ScreenWidth, ScreenHeight)
 {
 	startdbg;
 	dbg("Begin");
@@ -218,7 +218,7 @@ CHUDPanel::CHUDPanel(Panel *pParent) : VGUI_MainPanel(0, 0, 0, ScreenWidth, Scre
 
 	//ID Panel
 	dbg("Create ID");
-	m_ID = new VGUI_ID(this, STAMINA_X + STAMINA_SIZE_X + XRES(32), STAMINA_Y - 100);
+	m_ID = new VGUI_ID(this, ID_X, ID_Y);
 
 	//Vote Info Panel
 	dbg("Create Vote");
@@ -242,7 +242,7 @@ CHUDPanel::CHUDPanel(Panel *pParent) : VGUI_MainPanel(0, 0, 0, ScreenWidth, Scre
 	//SayText Console
 	dbg("Create SayText Console");
 #define SAYTEXTCON_X XRES(10)
-//thothie was 220, moving to 180
+	//thothie was 220, moving to 180
 #define SAYTEXTCON_Y YRES(180) //Starts here, and moves upward as it grows
 #define SAYTEXTCON_SIZE_X XRES(300)
 	Prefs.VisLines = "ms_txthud_size";
@@ -305,12 +305,12 @@ void CHUDPanel::Think()
 	enddbg;
 }
 
-void CHUDPanel::UpdateInfoWindows(mslist<CInfoWindow *> &Windows)
+void CHUDPanel::UpdateInfoWindows(mslist<CInfoWindow*>& Windows)
 {
 	//Count backwards because the objects might delete themselves
 	for (int i = Windows.size() - 1; i >= 0; i--)
 	{
-		CInfoWindow &InfoWin = *Windows[i];
+		CInfoWindow& InfoWin = *Windows[i];
 		//Update the Infowindow (for effects, like fade)
 		InfoWin.Update(Windows, i);
 
@@ -319,9 +319,9 @@ void CHUDPanel::UpdateInfoWindows(mslist<CInfoWindow *> &Windows)
 			RemoveInfoWindow(Windows, i);
 	}
 }
-void CHUDPanel::RemoveInfoWindow(mslist<CInfoWindow *> &Windows, int idx)
+void CHUDPanel::RemoveInfoWindow(mslist<CInfoWindow*>& Windows, int idx)
 {
-	CInfoWindow *pInfoWin = Windows[idx];
+	CInfoWindow* pInfoWin = Windows[idx];
 	Windows.erase(idx);
 	removeChild(pInfoWin);
 	pInfoWin->Remove();
@@ -377,7 +377,7 @@ void CHUDPanel::StepInput(hudscroll_e ScrollCmd)
 	else
 		m_ActiveConsole->StepInput(ScrollCmd == HUDSCROLL_DOWN);
 }
-bool CHUDPanel::KeyInput(int down, int keynum, const char *pszCurrentBinding)
+bool CHUDPanel::KeyInput(int down, int keynum, const char* pszCurrentBinding)
 {
 	if (m_StartSayText->isVisible())
 	{
@@ -392,62 +392,62 @@ void HUD_ShowInfoWin(msstring_ref Title, msstring_ref Text)
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
 
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->AddInfoWin(Title, Text);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->AddInfoWin(Title, Text);
 }
 void HUD_ShowHelpWin(msstring_ref Title, msstring_ref Text)
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
 
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->AddHelpWin(Title, Text);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->AddHelpWin(Title, Text);
 }
 void HUD_StepInput(hudscroll_e ScrollCmd)
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->StepInput(ScrollCmd);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->StepInput(ScrollCmd);
 }
-bool HUD_KeyInput(int down, int keynum, const char *pszCurrentBinding)
+bool HUD_KeyInput(int down, int keynum, const char* pszCurrentBinding)
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return false;
-	return ((CHUDPanel *)gViewPort->m_pHUDPanel)->KeyInput(down, keynum, pszCurrentBinding);
+	return ((CHUDPanel*)gViewPort->m_pHUDPanel)->KeyInput(down, keynum, pszCurrentBinding);
 }
 void HUD_PrintEvent(Color color, msstring_ref Text)
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->PrintEvent(color, Text);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->PrintEvent(color, Text);
 }
 void HUD_SayTextEvent(Color color, msstring_ref Text)
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->PrintSayText(color, Text);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->PrintSayText(color, Text);
 }
 
 void HUD_StartSayText(int Type)
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->m_StartSayText->Open(Type);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->m_StartSayText->Open(Type);
 }
 void HUD_CancelSayText()
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->m_StartSayText->setVisible(false);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->m_StartSayText->setVisible(false);
 }
 
-void HUD_DrawID(entinfo_t *pEntinfo)
+void HUD_DrawID(entinfo_t* pEntinfo)
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->m_ID->Update(pEntinfo);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->m_ID->Update(pEntinfo);
 }
 
 msstringlist HelpParts;
-int __MsgFunc_HUDInfoMsg(const char *pszName, int iSize, void *pbuf)
+int __MsgFunc_HUDInfoMsg(const char* pszName, int iSize, void* pbuf)
 {
 	BEGIN_READ(pbuf, iSize);
 
@@ -465,7 +465,7 @@ int __MsgFunc_HUDInfoMsg(const char *pszName, int iSize, void *pbuf)
 	{
 		//Print to Event console
 		ulong lColor = READ_LONG();
-		Color color(((uchar *)&lColor)[0], ((uchar *)&lColor)[1], ((uchar *)&lColor)[2], ((uchar *)&lColor)[3]);
+		Color color(((uchar*)&lColor)[0], ((uchar*)&lColor)[1], ((uchar*)&lColor)[2], ((uchar*)&lColor)[3]);
 		sText = READ_STRING();
 
 		HUD_PrintEvent(color, sText);
@@ -526,7 +526,7 @@ void __CmdFunc_QuickSlot()
 
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->m_QuickSlot->Select(Type);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->m_QuickSlot->Select(Type);
 }
 
 void QuickSlotPressed(bool fDown)
@@ -540,7 +540,7 @@ void QuickSlotPressed(bool fDown)
 
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->m_QuickSlot->SlotPressed(fDown, Slot);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->m_QuickSlot->SlotPressed(fDown, Slot);
 }
 
 void __CmdFunc_QuickSlotStart()
@@ -556,12 +556,12 @@ bool QuickSlotConfirm()
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return false;
-	return ((CHUDPanel *)gViewPort->m_pHUDPanel)->m_QuickSlot->ConfirmItem();
+	return ((CHUDPanel*)gViewPort->m_pHUDPanel)->m_QuickSlot->ConfirmItem();
 }
 
 void dbgtxt(msstring_ref Text)
 {
 	if (!gViewPort || !gViewPort->m_pHUDPanel)
 		return;
-	((CHUDPanel *)gViewPort->m_pHUDPanel)->m_DebugText->setText(Text);
+	((CHUDPanel*)gViewPort->m_pHUDPanel)->m_DebugText->setText(Text);
 }

--- a/game/client/ui/ms/vgui_id.h
+++ b/game/client/ui/ms/vgui_id.h
@@ -78,7 +78,7 @@ public:
 		else if (currHP >= maxHP * WOUNDED_HPMOD && currHP < maxHP * INJURED_HPMOD)
 		{
 			cHPColor = COLOR(255, 255, 0, 0);
-			sHPBracketName = "Lightly Wounded";
+			sHPBracketName = "Wounded";
 		}
 		else if (currHP >= maxHP * CRITICAL_HPMOD && currHP < maxHP * WOUNDED_HPMOD)
 		{

--- a/game/client/ui/ms/vgui_id.h
+++ b/game/client/ui/ms/vgui_id.h
@@ -72,7 +72,7 @@ public:
 		}
 		else if (currHP >= maxHP * INJURED_HPMOD && currHP < maxHP * HEALTHY_HPMOD)
 		{
-			cHPColor = COLOR(200, 255, 0, 0);
+			cHPColor = COLOR(188, 255, 0, 0);
 			sHPBracketName = "Barely Injured";
 		}
 		else if (currHP >= maxHP * WOUNDED_HPMOD && currHP < maxHP * INJURED_HPMOD)

--- a/game/client/ui/ms/vgui_id.h
+++ b/game/client/ui/ms/vgui_id.h
@@ -10,6 +10,8 @@ public:
 	entinfo_t* m_LastID;
 	cl_entity_s* m_pClientEnt;
 	int iCurrentAlpha = 0;
+	int iCurrentWidth = 200;
+	int iCurrentHeight = 10 + g_FontID->getTall() * 3;
 
 #define ID_X XRES(320)
 #define ID_Y YRES(240)
@@ -17,7 +19,7 @@ public:
 #define WOUNDED_HPMOD 0.50
 #define CRITICAL_HPMOD 0.25
 
-	VGUI_ID(Panel* pParent, int x, int y) : Panel(x, y, XRES(50), 10 + g_FontID->getTall()*3)
+	VGUI_ID(Panel* pParent, int x, int y) : Panel(x, y, iCurrentWidth, iCurrentWidth)
 	{
 		setParent(pParent);
 		setBgColor(0, 0, 0, 255);
@@ -175,6 +177,7 @@ public:
 		int iIntendedY = ID_Y + flCVARIdOffsetY;
 		int iCurrentX;
 		int iCurrentY;
+
 		getPos(iCurrentX, iCurrentY);
 
 		if (iCurrentX != iIntendedX || iCurrentY != iIntendedY)
@@ -194,14 +197,8 @@ public:
 
 		std::string sCVARHUDIDBackground = CVAR_GET_STRING("msui_id_background");
 
-		if (sCVARHUDIDBackground == "1") {
-				if (m_LastID != NULL)
-				{
-					FadeInTo(100);
-				}
-				else {
-					FadeOut();
-				}
+		if (sCVARHUDIDBackground == "1" && m_LastID != NULL) {
+			FadeInTo(100);
 		}
 		else {
 			if (iCurrentAlpha != 255) {
@@ -209,10 +206,26 @@ public:
 			}
 		}
 
+		int iWidestLabelWidth = 200;
+
+		for (int idx = 0; idx < 3; idx++) {
+			if (m_Label[idx]->getWide() > iWidestLabelWidth)
+				iWidestLabelWidth = m_Label[idx]->getWide();
+		}
+
+		if (iWidestLabelWidth > iCurrentWidth)
+		{
+			iCurrentWidth = iWidestLabelWidth;
+			setSize(iCurrentWidth, iCurrentHeight);
+		}
+		else if (this->getWide() != iCurrentWidth) {
+			setSize(iCurrentWidth, iCurrentHeight);
+		}
+
 		setVisible(ShowHUD());
 	}
 	void FadeInTo(int iTargetAlpha) {
-		
+
 		while (iCurrentAlpha > iTargetAlpha) {
 			iCurrentAlpha = iCurrentAlpha - 1;
 			this->setBgColor(0, 0, 0, iCurrentAlpha);

--- a/game/client/ui/ms/vgui_id.h
+++ b/game/client/ui/ms/vgui_id.h
@@ -9,6 +9,7 @@ public:
 	VGUI_FadeText* m_Label[3];
 	entinfo_t* m_LastID;
 	cl_entity_s* m_pClientEnt;
+	int iCurrentAlpha = 0;
 
 #define ID_X XRES(320)
 #define ID_Y YRES(240)
@@ -16,14 +17,14 @@ public:
 #define WOUNDED_HPMOD 0.50
 #define CRITICAL_HPMOD 0.25
 
-	VGUI_ID(Panel* pParent, int x, int y) : Panel(x, y, XRES(200), YRES(54))
+	VGUI_ID(Panel* pParent, int x, int y) : Panel(x, y, XRES(50), 10 + g_FontID->getTall()*3)
 	{
 		setParent(pParent);
 		setBgColor(0, 0, 0, 255);
 
 		for (int i = 0; i < 3; i++)
 		{
-			m_Label[i] = new VGUI_FadeText(this, 1, "", 0, i * g_FontID->getTall(), MSLabel::a_west);
+			m_Label[i] = new VGUI_FadeText(this, 0.2, "", 0, i * g_FontID->getTall(), MSLabel::a_west);
 			m_Label[i]->setFont(g_FontID);
 		}
 		m_Label[0]->SetFGColorRGB(Color_Text_White);
@@ -66,9 +67,14 @@ public:
 			cHPColor = COLOR(0, 255, 0, 0);
 			sHPBracketName = "Healthy";
 		}
-		else if (currHP > maxHP * WOUNDED_HPMOD)
+		else if (currHP > maxHP * WOUNDED_HPMOD && currHP < maxHP * HEALTHY_HPMOD)
 		{
 			cHPColor = COLOR(255, 255, 0, 0);
+			sHPBracketName = "Slightly Wounded";
+		}
+		else if (currHP < maxHP * WOUNDED_HPMOD && currHP > maxHP * CRITICAL_HPMOD)
+		{
+			cHPColor = COLOR(255, 188, 0, 0);
 			sHPBracketName = "Wounded";
 		}
 		else if (currHP < maxHP * CRITICAL_HPMOD) {
@@ -186,7 +192,40 @@ public:
 		//make sure we have the same alpha as the first element, fixes fade in as well as correctly updating health color in realtime
 		m_Label[2]->setFgColor(cHPColor.r, cHPColor.g, cHPColor.b, iCurrentIndendedAlpha);
 
+		std::string sCVARHUDIDBackground = CVAR_GET_STRING("msui_id_background");
+
+		if (sCVARHUDIDBackground == "1") {
+				if (m_LastID != NULL)
+				{
+					FadeInTo(100);
+				}
+				else {
+					FadeOut();
+				}
+		}
+		else {
+			if (iCurrentAlpha != 255) {
+				FadeOut();
+			}
+		}
+
 		setVisible(ShowHUD());
+	}
+	void FadeInTo(int iTargetAlpha) {
+		
+		while (iCurrentAlpha > iTargetAlpha) {
+			iCurrentAlpha = iCurrentAlpha - 1;
+			this->setBgColor(0, 0, 0, iCurrentAlpha);
+		}
+
+	}
+	void FadeOut() {
+
+		while (iCurrentAlpha < 255) {
+			iCurrentAlpha = iCurrentAlpha + 1;
+			this->setBgColor(0, 0, 0, iCurrentAlpha);
+		}
+
 	}
 	void NewLevel()
 	{

--- a/game/client/ui/ms/vgui_id.h
+++ b/game/client/ui/ms/vgui_id.h
@@ -24,7 +24,7 @@ public:
 
 		for (int i = 0; i < 3; i++)
 		{
-			m_Label[i] = new VGUI_FadeText(this, 0.2, "", 0, i * g_FontID->getTall(), MSLabel::a_west);
+			m_Label[i] = new VGUI_FadeText(this, 0.2, "", 0, i * g_FontID->getTall(), MSLabel::a_center);
 			m_Label[i]->setFont(g_FontID);
 		}
 		m_Label[0]->SetFGColorRGB(Color_Text_White);

--- a/game/client/ui/ms/vgui_id.h
+++ b/game/client/ui/ms/vgui_id.h
@@ -5,18 +5,25 @@
 class VGUI_ID : public Panel
 {
 public:
-	VGUI_FadeText *m_Label[2];
-	entinfo_t *m_LastID;
-	cl_entity_s *m_pClientEnt;
+	COLOR cHPColor = COLOR(0, 0, 0, 0);;
+	VGUI_FadeText* m_Label[3];
+	entinfo_t* m_LastID;
+	cl_entity_s* m_pClientEnt;
 
-	VGUI_ID(Panel *pParent, int x, int y) : Panel(x, y, XRES(200), YRES(36))
+#define ID_X XRES(320)
+#define ID_Y YRES(240)
+#define HEALTHY_HPMOD 0.75
+#define WOUNDED_HPMOD 0.50
+#define CRITICAL_HPMOD 0.25
+
+	VGUI_ID(Panel* pParent, int x, int y) : Panel(x, y, XRES(200), YRES(54))
 	{
 		setParent(pParent);
 		setBgColor(0, 0, 0, 255);
 
-		for (int i = 0; i < 2; i++)
+		for (int i = 0; i < 3; i++)
 		{
-			m_Label[i] = new VGUI_FadeText(this, 1, "", 0, 0 + i * g_FontID->getTall(), MSLabel::a_west);
+			m_Label[i] = new VGUI_FadeText(this, 1, "", 0, i * g_FontID->getTall(), MSLabel::a_west);
 			m_Label[i]->setFont(g_FontID);
 		}
 		m_Label[0]->SetFGColorRGB(Color_Text_White);
@@ -30,12 +37,13 @@ public:
 		if (m_LastID == NULL)
 			return;
 
-		static char pchOutputString[MSSTRING_SIZE];
-		_snprintf(pchOutputString, MSSTRING_SIZE, "%s", m_LastID->Name.c_str());
+		static char pchNameString[MSSTRING_SIZE];
+		static char pchHealthString[MSSTRING_SIZE];
+		_snprintf(pchNameString, MSSTRING_SIZE, "%s", m_LastID->Name.c_str());
 
 		if (m_pClientEnt == NULL)
 		{
-			m_Label[0]->setText(pchOutputString);
+			m_Label[0]->setText(pchNameString);
 			return;
 		}
 
@@ -43,15 +51,36 @@ public:
 		int currHP = ((int)m_pClientEnt->curstate.vuser3.y);
 		if ((maxHP <= 0) || (currHP <= 0))
 		{
-			m_Label[0]->setText(pchOutputString);
+			m_Label[0]->setText(pchNameString);
 			return;
 		}
 
-		_snprintf(pchOutputString, MSSTRING_SIZE, "%s (%i / %i)", m_LastID->Name.c_str(), currHP, maxHP);
-		m_Label[0]->setText(pchOutputString);
+		_snprintf(pchNameString, MSSTRING_SIZE, "%s", m_LastID->Name.c_str());
+		m_Label[0]->setText(pchNameString);
+
+		//move hp text to new line and make it colorful
+		msstring sHPBracketName;
+		
+		//color the health portion appropriately
+		if (currHP > maxHP * HEALTHY_HPMOD) {
+			cHPColor = COLOR(0, 255, 0, 0);
+			sHPBracketName = "Healthy";
+		}
+		else if (currHP > maxHP * WOUNDED_HPMOD)
+		{
+			cHPColor = COLOR(255, 255, 0, 0);
+			sHPBracketName = "Wounded";
+		}
+		else if (currHP < maxHP * CRITICAL_HPMOD) {
+			cHPColor = COLOR(255, 0, 0, 0);
+			sHPBracketName = "Near Death";
+		}
+
+		_snprintf(pchHealthString, MSSTRING_SIZE, "%s (%i / %i)", sHPBracketName.c_str(), currHP, maxHP);
+		m_Label[2]->setText(pchHealthString);
 	}
 
-	void Update(entinfo_t *pEntInfo)
+	void Update(entinfo_t* pEntInfo)
 	{
 		SetStatus();
 
@@ -101,17 +130,20 @@ public:
 				DifficultyColor = COLOR(200, 200, 200, 0);
 				break;
 			}
-			
+
 			}
 
 			m_Label[1]->setText(String);
 			m_Label[1]->SetFGColorRGB(DifficultyColor);
+			//hpcolor needs to be set here otherwise it breaks the fadein
+			m_Label[2]->SetFGColorRGB(cHPColor);
 			m_Label[0]->StartFade(false);
 			m_Label[1]->StartFade(false);
+			m_Label[2]->StartFade(false);
 		}
 		else
 		{
-			for (int i = 0; i < 2; i++)
+			for (int i = 0; i < 3; i++)
 			{
 				float PrevDelta = gpGlobals->time - m_Label[i]->m_StartTime;
 				PrevDelta = min(PrevDelta, m_Label[i]->m_FadeDuration);
@@ -123,18 +155,35 @@ public:
 		m_LastID = pEntInfo;
 		m_pClientEnt = (pEntInfo ? gEngfuncs.GetEntityByIndex(pEntInfo->entindex) : NULL);
 		SetStatus();
-		for (int i = 0; i < 2; i++)
+		for (int i = 0; i < 3; i++)
 			m_Label[i]->Update();
 	}
 	void Update()
 	{
-		for (int i = 0; i < 2; i++)
+		for (int i = 0; i < 3; i++)
 			m_Label[i]->Update();
+
+		//get our wanted position
+		float flCVARIdOffsetX = CVAR_GET_FLOAT("msui_id_offsetx");
+		float flCVARIdOffsetY = CVAR_GET_FLOAT("msui_id_offsety");
+
+		//wee bad engine functions making me define four ints!
+		int iIntendedX = ID_X + flCVARIdOffsetX;
+		int iIntendedY = ID_Y + flCVARIdOffsetY;
+		int iCurrentX;
+		int iCurrentY;
+		getPos(iCurrentX, iCurrentY);
+
+		if (iCurrentX != iIntendedX || iCurrentY != iIntendedY)
+		{
+			setPos(iIntendedX, iIntendedY);
+		}
+
 		setVisible(ShowHUD());
 	}
 	void NewLevel()
 	{
-		for (int i = 0; i < 2; i++)
+		for (int i = 0; i < 3; i++)
 		{
 			m_Label[i]->m_StartTime = -1000; //Ensure ID doesn't show up after a level change
 			m_Label[i]->setText("");

--- a/game/client/ui/ms/vgui_id.h
+++ b/game/client/ui/ms/vgui_id.h
@@ -15,7 +15,8 @@ public:
 
 #define ID_X XRES(320)
 #define ID_Y YRES(240)
-#define HEALTHY_HPMOD 0.75
+#define HEALTHY_HPMOD 0.95
+#define INJURED_HPMOD 0.75
 #define WOUNDED_HPMOD 0.50
 #define CRITICAL_HPMOD 0.25
 
@@ -65,21 +66,26 @@ public:
 		msstring sHPBracketName;
 
 		//color the health portion appropriately
-		if (currHP > maxHP * HEALTHY_HPMOD) {
+		if (currHP >= maxHP * HEALTHY_HPMOD) {
 			cHPColor = COLOR(0, 255, 0, 0);
 			sHPBracketName = "Healthy";
 		}
-		else if (currHP > maxHP * WOUNDED_HPMOD && currHP < maxHP * HEALTHY_HPMOD)
+		else if (currHP >= maxHP * INJURED_HPMOD && currHP < maxHP * HEALTHY_HPMOD)
+		{
+			cHPColor = COLOR(200, 255, 0, 0);
+			sHPBracketName = "Barely Injured";
+		}
+		else if (currHP >= maxHP * WOUNDED_HPMOD && currHP < maxHP * INJURED_HPMOD)
 		{
 			cHPColor = COLOR(255, 255, 0, 0);
-			sHPBracketName = "Slightly Wounded";
+			sHPBracketName = "Lightly Wounded";
 		}
-		else if (currHP < maxHP * WOUNDED_HPMOD && currHP > maxHP * CRITICAL_HPMOD)
+		else if (currHP >= maxHP * CRITICAL_HPMOD && currHP < maxHP * WOUNDED_HPMOD)
 		{
 			cHPColor = COLOR(255, 188, 0, 0);
-			sHPBracketName = "Wounded";
+			sHPBracketName = "Severely Wounded";
 		}
-		else if (currHP < maxHP * CRITICAL_HPMOD) {
+		else if (currHP <= maxHP * CRITICAL_HPMOD) {
 			cHPColor = COLOR(255, 0, 0, 0);
 			sHPBracketName = "Near Death";
 		}

--- a/game/client/ui/ms/vgui_id.h
+++ b/game/client/ui/ms/vgui_id.h
@@ -60,7 +60,7 @@ public:
 
 		//move hp text to new line and make it colorful
 		msstring sHPBracketName;
-		
+
 		//color the health portion appropriately
 		if (currHP > maxHP * HEALTHY_HPMOD) {
 			cHPColor = COLOR(0, 255, 0, 0);
@@ -135,11 +135,8 @@ public:
 
 			m_Label[1]->setText(String);
 			m_Label[1]->SetFGColorRGB(DifficultyColor);
-			//hpcolor needs to be set here otherwise it breaks the fadein
-			m_Label[2]->SetFGColorRGB(cHPColor);
 			m_Label[0]->StartFade(false);
 			m_Label[1]->StartFade(false);
-			m_Label[2]->StartFade(false);
 		}
 		else
 		{
@@ -178,6 +175,16 @@ public:
 		{
 			setPos(iIntendedX, iIntendedY);
 		}
+
+		SetStatus();
+		//attempting to make it update correctly since the health color is late to update.
+		//i hate this vgui engine it is so annoying to deal with.
+
+		int iTemp; // because who would want just a single one of the colors of an element ever right?
+		int iCurrentIndendedAlpha;
+		m_Label[0]->getFgColor(iTemp, iTemp, iTemp, iCurrentIndendedAlpha);
+		//make sure we have the same alpha as the first element, fixes fade in as well as correctly updating health color in realtime
+		m_Label[2]->setFgColor(cHPColor.r, cHPColor.g, cHPColor.b, iCurrentIndendedAlpha);
 
 		setVisible(ShowHUD());
 	}


### PR DESCRIPTION
Two new cvars:
msui_id_offsetx
msui_id_offsety

These are used to move the id ui around and can be negative, by default it is to the bottom right of the crosshair now

Additionally the health text has been given a new line with some more flavour text as well as coloring.
If we want more health levels (like the ones in NWN) this is easily expandable by defining them for easy changing later as well as adding them to the elseif chain with the wanted colors.

Related Issue: #90 