### PR TITLE
Cleanup console warning spam on map start

### DIFF
--- a/game/client/hud_spectator.cpp
+++ b/game/client/hud_spectator.cpp
@@ -1565,7 +1565,7 @@ void CHudSpectator::Reset()
 	if (strcmp(m_OverviewData.map, gEngfuncs.pfnGetLevelName()))
 	{
 		// update level overview if level changed
-		ParseOverviewFile();
+		// ParseOverviewFile(); // Overviews are not used in MSR as of now, and clutter the console with warnings when trying to load --thesupersoup 2023/07/09
 		LoadMapSprites();
 	}
 

--- a/game/client/ui/vgui_customobjects.cpp
+++ b/game/client/ui/vgui_customobjects.cpp
@@ -68,6 +68,12 @@ char *GetTGANameForRes(const char *pszName)
 //-----------------------------------------------------------------------------
 BitmapTGA *LoadTGAForRes(const char *pImageName)
 {
+	// This is a super hacky way to prevent attempts to load null
+	// or zero-length name files. The best solution would be to 
+	// prevent such attempts, but alas... --thesupersoup, 2023/07/09
+	if (!pImageName || strlen(pImageName) <= 0)
+		return nullptr;
+
 	BitmapTGA *pTGA = nullptr;
 
 	char sz[256];
@@ -430,7 +436,6 @@ CTFScrollButton::CTFScrollButton(int iArrow, const char *text, int x, int y, int
 	setFgColor(Scheme::sc_primary1);
 
 	// Load in the arrow
-	//m_pTGA = LoadTGAForRes( sArrowFilenames[iArrow] );
 	m_pTGA = MSBitmap::GetTGA(sArrowFilenames[iArrow]);
 	setImage(m_pTGA);
 

--- a/game/shared/ms/scriptcmds.cpp
+++ b/game/shared/ms/scriptcmds.cpp
@@ -2938,7 +2938,10 @@ bool CScript::ScriptCmd_DeleteEntity(SCRIPT_EVENT& Event, scriptcmd_t& Cmd, msst
 
 //desc
 //- scope: shared, items
-//- Descriptions for items - limited to 72 characters.
+//- Descriptions for items
+
+const int SCRIPT_DESC_MAX_LENGTH = 96;
+
 bool CScript::ScriptCmd_Desc(SCRIPT_EVENT &Event, scriptcmd_t &Cmd, msstringlist &Params)
 {
 	msstring sTemp;
@@ -2948,9 +2951,9 @@ bool CScript::ScriptCmd_Desc(SCRIPT_EVENT &Event, scriptcmd_t &Cmd, msstringlist
 		{
 			if (i) sTemp += " ";  sTemp += Params[i];
 		}
-		if (sTemp.len() > 72)
+		if (sTemp.len() > SCRIPT_DESC_MAX_LENGTH)
 		{
-			sTemp = sTemp.substr(0, 72); //APR2011_28 - Thothie buffer overrun
+			sTemp = sTemp.substr(0, SCRIPT_DESC_MAX_LENGTH); //APR2011_28 - Thothie buffer overrun
 			IScripted *pScripted = m.pScriptedEnt->GetScripted();
 			Print("WARNING: Description too long [%s]!\n", pScripted->m_Scripts[0]->m.ScriptFile.c_str());
 		}


### PR DESCRIPTION
Partially resolves https://github.com/MSRevive/MasterSwordRebirth/issues/186

Paired with https://github.com/MSRevive/assets/pull/17

- Prevented parsing the spectator overview, which is a seemingly unused feature in MSR
- Added code to protect against attempting to load a null or zero-length file in `LoadTGAForRes`, although the _real_ solution would be to find where those null or empty string filenames were being pulled from to begin with, which I couldn't.
- Upped the scripted item description limit to 96 chars. I think the limit may have been preventing a problem which has since been resolved, as I tested drawing one of the affected weapons to trigger the description message several dozen times while moving through level transitions without any errors. Either way, this keeps an upper limit on it for now while fitting all of the current item descriptions.