### PR TITLE
Fix crash in CHudSpectator::SetSpectatorStartPosition

### DIFF
--- a/src/game/client/hud_spectator.cpp
+++ b/src/game/client/hud_spectator.cpp
@@ -352,8 +352,11 @@ void CHudSpectator::SetSpectatorStartPosition()
 	else
 	{
 		// jump to 0,0,0 if no better position was found
-		VectorCopy(vec3_origin, m_cameraOrigin);
-		VectorCopy(vec3_origin, m_cameraAngles);
+		if (vec3_origin != NULL)
+		{
+			VectorCopy(vec3_origin, m_cameraOrigin);
+			VectorCopy(vec3_origin, m_cameraAngles);
+		}
 	}
 
 	VectorCopy(m_cameraOrigin, vJumpOrigin);


### PR DESCRIPTION
Not sure if anyone else was seeing this but the game was crashing before getting to the main menu without this. Weirdly it didn't generate a crash dump but attaching the debugger showed it.