### PR TITLE
Fix build scripts using relative paths with CMake.

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -4,7 +4,7 @@ set -eu
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
-path=.
+path=$(realpath .)
 type=Release
 
 while getopts "p:t:" opt; do

--- a/createall.sh
+++ b/createall.sh
@@ -4,7 +4,7 @@ set -eu
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
-path=.
+path=$(realpath .)
 type=Release
 
 while getopts "p:t:" opt; do


### PR DESCRIPTION
Building locally didn't work with local paths.