### PR TITLE
Strip edicts on env_model and env_sprite with no targetname

### DIFF
--- a/src/common/const.h
+++ b/src/common/const.h
@@ -42,7 +42,8 @@
 
 // UNDONE: Do we need these?
 #define FL_IMMUNE_WATER (1 << 17)
-#define FL_IMMUNE_SLIME (1 << 18)
+//#define FL_IMMUNE_SLIME (1 << 18)
+#define FL_CLIENTONLY (1 << 18)		// Strip edicts
 #define FL_IMMUNE_LAVA (1 << 19)
 
 #define FL_PROXY (1 << 20)		  // This is a spectator proxy

--- a/src/game/server/effects.cpp
+++ b/src/game/server/effects.cpp
@@ -1139,6 +1139,17 @@ void CSprite::Spawn(void)
 	SET_MODEL(ENT(pev), STRING(pev->model));
 
 	m_maxFrame = (float)MODEL_FRAMES(pev->modelindex) - 1;
+
+	// Strip edicts with no targetname or parent
+	if (FStringNull(pev->targetname) && FNullEnt(pev->aiment))
+	{
+		pev->flags |= FL_CLIENTONLY;
+
+		SET_MODEL(ENT(pev), iStringNull);
+		UTIL_Remove(this);
+		return;
+	}
+
 	if (pev->targetname && !(pev->spawnflags & SF_SPRITE_STARTON))
 		TurnOff();
 	else

--- a/src/game/server/hl/cbase.h
+++ b/src/game/server/hl/cbase.h
@@ -400,7 +400,10 @@ public:
 	virtual void KeyValue(KeyValueData *pkvd) { pkvd->fHandled = FALSE; }
 	virtual int Save(CSave &save);
 	virtual int Restore(CRestore &restore);
-	virtual int ObjectCaps(void) { return FCAP_ACROSS_TRANSITION; }
+
+	// Strip edicts safety check - prevent saving FL_CLIENTONLY entities
+	virtual int ObjectCaps(void) { return (this->pev->flags & FL_CLIENTONLY) ? FCAP_DONT_SAVE : FCAP_ACROSS_TRANSITION; }
+	
 	virtual void Activate(void) {}
 
 	// Setup the object->object collision box (pev->mins / pev->maxs is the object->world collision box)

--- a/src/game/server/msmapents.cpp
+++ b/src/game/server/msmapents.cpp
@@ -319,6 +319,14 @@ public:
 		pev->controller[1] = 255 / 2;
 		pev->controller[2] = 255 / 2;
 		pev->controller[3] = 255 / 2;
+
+		// Strip Edicts with no targetname
+		if (FStringNull(this->pev->targetname))
+		{
+			this->pev->flags |= FL_CLIENTONLY;
+			SET_MODEL(ENT(this->pev), iStringNull);
+			UTIL_Remove(this);
+		}
 	}
 };
 LINK_ENTITY_TO_CLASS(env_model, CStaticModel);


### PR DESCRIPTION
Closes #306. Strips edicts for env_model and env_sprite with no targetname. Added a safety check to prevent saving stripped (invalid) entities.