### PR TITLE
Preas - Low charge modifier towards damage #346

### DIFF
--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -788,12 +788,11 @@ void CGenericItem::StrikeLand()
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 
-	Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
+	//Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
 	if (m_LastChargedAmt < 1)
 	{
 		flDamage *= (m_LastChargedAmt + 1);
-		Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
-
+		//Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
 	}
 
 	SetDebugProgress(ItemThinkProgress, "CGenericItem::StrikeLand - Call DoDamage");

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -788,11 +788,12 @@ void CGenericItem::StrikeLand()
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 
-	//Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
-	if (m_LastChargedAmt > 0 && m_LastChargedAmt < 1)
+	Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
+	if (m_LastChargedAmt < 1)
 	{
-		Print("Out damage: %f\n", flDamage *= m_LastChargedAmt);
-		flDamage *= m_LastChargedAmt;
+		flDamage *= (m_LastChargedAmt + 1);
+		Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
+
 	}
 
 	SetDebugProgress(ItemThinkProgress, "CGenericItem::StrikeLand - Call DoDamage");


### PR DESCRIPTION
Charge Modifier was being passed in as a decimal between 0 and 1.
Charge modifier was being applied twice.

Changed modifier to be a muiltiple  greater than 1 (0.5 charge = 1.5 multiplier)
Changed modifier to only apply once.

Notes to consider, depending on how damage is considered for charge levels outside of partial charge, this could more heavily result in charge attacks that do less damage than then partial charge of lower level.

Is this is intended, such as reduced damage for debuff effect, like hammer stun, then ok.
Otherwise, would it be similarly recommended to offer similar range scale, a charge level 1 can be similar scaled if not yet two, etc.

fixes #346 
