### PR TITLE
Preas - Issue #346 

### DIFF
--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -788,13 +788,6 @@ void CGenericItem::StrikeLand()
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 
-	//Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
-	if (m_LastChargedAmt < 1)
-	{
-		flDamage *= (m_LastChargedAmt + 1);
-		//Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
-	}
-
 	SetDebugProgress(ItemThinkProgress, "CGenericItem::StrikeLand - Call DoDamage");
 	int bitsDamage = DMG_CLUB;
 	if (!m_pPlayer)

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -788,12 +788,11 @@ void CGenericItem::StrikeLand()
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 
-	Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
+	//Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
 	if (m_LastChargedAmt < 1)
 	{
 		flDamage *= (m_LastChargedAmt + 1);
-		Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
-
+		//Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
 	}
 
 	SetDebugProgress(ItemThinkProgress, "CGenericItem::StrikeLand - Call DoDamage");

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -788,11 +788,12 @@ void CGenericItem::StrikeLand()
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 
-	//Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
-	if (m_LastChargedAmt > 0 && m_LastChargedAmt < 1)
+	Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
+	if (m_LastChargedAmt < 1)
 	{
-		Print("Out damage: %f\n", flDamage *= m_LastChargedAmt);
-		flDamage *= m_LastChargedAmt;
+		flDamage *= (m_LastChargedAmt + 1);
+		Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
+
 	}
 
 	SetDebugProgress(ItemThinkProgress, "CGenericItem::StrikeLand - Call DoDamage");


### PR DESCRIPTION
Removed charge modifiers to damage within StrikeLand().

Charge modifier damage is calculated through script call backs.
Testing: regardless of charge level, m_LastChargedAmt was always zero during StrikeLand() regardless if partial charge was used.

Can reasonably assert if issue persists, there is a syncronization issue with script call backs.
I have not been able to replicate the problem on listen servers, but can pretty regularly reproduce issue #346 on a non-local server indicating latency is relevant.
