### PR TITLE
Preas - Cleanup / Fixed Title Missing from Player Info Panel

### DIFF
--- a/src/game/client/ui/ms/vgui_stats.cpp
+++ b/src/game/client/ui/ms/vgui_stats.cpp
@@ -217,6 +217,7 @@ void CStatPanel::Update()
 {
 	pMainPanel->setVisible(true);
 
+
 	int i;
 	char cDisplayText[128];
 	for (i = 0; i < INFO_STAT_NUM; i++)
@@ -230,7 +231,7 @@ void CStatPanel::Update()
 			 _snprintf(cDisplayText, sizeof(cDisplayText),  "Gender: %s\n",  GenderList[player.m_Gender] );
 			break;
 		case 2:
-			 _snprintf(cDisplayText, sizeof(cDisplayText),  "%s %s\n", "human",  player.GetTitle() );
+			 _snprintf(cDisplayText, sizeof(cDisplayText),  "%s %s\n", "Human",  player.GetTitle());
 			break;
 		case 3:
 			cDisplayText[0] = 0;

--- a/src/game/server/player/playershared.cpp
+++ b/src/game/server/player/playershared.cpp
@@ -150,13 +150,16 @@ title_t* CTitleManager::GetPlayerTitle(CBasePlayer* pPlayer)
 
 		//Is this the first valid title, or is this title better than the previous best title?
 
-		if (!pBestTitle) {
+		if (!pBestTitle)
+		{
 			pBestTitle = &Title;
 		}
-		else if (Title.SkillsReq.size() > pBestTitle->SkillsReq.size()) {
+		else if (Title.SkillsReq.size() > pBestTitle->SkillsReq.size())
+		{
 			pBestTitle = &Title;
 		}
-		else if (Title.MinLevel > pBestTitle->MinLevel) {
+		else if (Title.MinLevel > pBestTitle->MinLevel)
+		{
 			pBestTitle = &Title;
 		}
 
@@ -173,21 +176,21 @@ const char* CBasePlayer::GetTitle()
 		return CustomTitle.c_str();
 
 	title_t* pTitle = CTitleManager::GetPlayerTitle(this);
-	if (pTitle) {
+	if (pTitle)
+	{
 		return pTitle->Name.c_str();
 	}
-	else {
+	else
+	{
 		return CTitleManager::DefaultTitle.Name.c_str();
 	}
-	
 }
 
 const char* CBasePlayer::GetFullTitle()
 {
 	//Lark DEC2017_16: Only replace old titles if CustomTitle is set.
-	if (!CustomTitle.contains("NONESET") && CustomTitle) {
+	if (!CustomTitle.contains("NONESET") && CustomTitle) 
 		return CustomTitle.c_str();
-	}
 
 	title_t* pTitle = CTitleManager::GetPlayerTitle(this);
 	if (pTitle)
@@ -213,7 +216,8 @@ const char* CBasePlayer::GetFullTitle()
 		Title += pTitle->Name;
 		return Title.c_str();
 	}
-	else {
+	else
+	{
 		return CTitleManager::DefaultTitle.Name.c_str();
 	}
 }

--- a/src/game/server/player/playershared.cpp
+++ b/src/game/server/player/playershared.cpp
@@ -168,56 +168,54 @@ title_t* CTitleManager::GetPlayerTitle(CBasePlayer* pPlayer)
 const char* CBasePlayer::GetTitle()
 {
 	//Lark DEC2017_16: Only replace old titles if CustomTitle is set.
+
 	if (!CustomTitle.contains("NONESET") && CustomTitle)
 		return CustomTitle.c_str();
-	else
-	{
-		//Old Way
-		title_t* pTitle = CTitleManager::GetPlayerTitle(this);
-		if (pTitle) {
-			return pTitle->Name.c_str();
-		}
-		else {
-			return CTitleManager::DefaultTitle.Name.c_str();
-		}
+
+	title_t* pTitle = CTitleManager::GetPlayerTitle(this);
+	if (pTitle) {
+		return pTitle->Name.c_str();
 	}
+	else {
+		return CTitleManager::DefaultTitle.Name.c_str();
+	}
+	
 }
 
 const char* CBasePlayer::GetFullTitle()
 {
 	//Lark DEC2017_16: Only replace old titles if CustomTitle is set.
-	if (!CustomTitle.contains("NONESET"))
-		return CustomTitle;
-	else
-	{
-		//Old Way
-		title_t* pTitle = CTitleManager::GetPlayerTitle(this);
-		if (pTitle)
-		{
-			static msstring Title;   //Format: "<skilllevel> Title"
-
-			Title = "";
-
-			int SkillLevel = 0;
-			int SkillsReq = pTitle->SkillsReq.size();
-			if (SkillsReq)   //Only add the skill level if this title requires skills
-			{
-				for (int s = 0; s < SkillsReq; s++)
-				{
-					SkillLevel += GetSkillStat(pTitle->SkillsReq[s]);
-				}
-				SkillLevel /= SkillsReq;
-
-				Title += SkillLevel;
-				Title += " ";
-			}
-
-			Title += pTitle->Name;
-			return Title.c_str();
-		}
+	if (!CustomTitle.contains("NONESET") && CustomTitle) {
+		return CustomTitle.c_str();
 	}
 
-	return "Unknown";
+	title_t* pTitle = CTitleManager::GetPlayerTitle(this);
+	if (pTitle)
+	{
+		static msstring Title;   //Format: "<skilllevel> Title"
+
+		Title = "";
+
+		int SkillLevel = 0;
+		int SkillsReq = pTitle->SkillsReq.size();
+		if (SkillsReq)   //Only add the skill level if this title requires skills
+		{
+			for (int s = 0; s < SkillsReq; s++)
+			{
+				SkillLevel += GetSkillStat(pTitle->SkillsReq[s]);
+			}
+			SkillLevel /= SkillsReq;
+
+			Title += SkillLevel;
+			Title += " ";
+		}
+
+		Title += pTitle->Name;
+		return Title.c_str();
+	}
+	else {
+		return CTitleManager::DefaultTitle.Name.c_str();
+	}
 }
 
 bool CBasePlayer::CreateStats()

--- a/src/game/server/player/playershared.cpp
+++ b/src/game/server/player/playershared.cpp
@@ -117,6 +117,7 @@ title_t* CTitleManager::GetPlayerTitle(CBasePlayer* pPlayer)
 	{
 		title_t& Title = Titles[i];
 		bool SkillsAreValid = true;
+
 		for (int s = 0; s < Title.SkillsReq.size(); s++)
 		{
 			int Skill = Title.SkillsReq[s] - SKILL_FIRSTSKILL;
@@ -128,20 +129,16 @@ title_t* CTitleManager::GetPlayerTitle(CBasePlayer* pPlayer)
 				break;
 			} //Skill not high enough
 
-			/*#ifndef VALVE_DLL
-		Print( "Title: %s Skill #%i, [%i]%s (%i/%i)\n", STRING(Title.Name), s, Title.SkillsReq[s], GetSkillName( SKILL_FIRSTSKILL + Skills[Skill].Skill ), Skills[Skill].Value, Title.MinLevel );
-#endif*/
-
-//Is this skill the highest skill? (If x skills are required, then is it one of the top x skills?)
 			bool IsHighestSkill = false;
-			for (int h = 0; h < Title.SkillsReq.size(); h++)
+			for (int h = 0; h < Title.SkillsReq.size(); h++) 
+			{
 				if (SortedSkills[h].Skill == Skill)
 				{
 					IsHighestSkill = true;
 					break;
 				}
-
-			if (!IsHighestSkill)
+			}
+			if (!IsHighestSkill) 
 			{
 				SkillsAreValid = false;
 				break;
@@ -152,12 +149,17 @@ title_t* CTitleManager::GetPlayerTitle(CBasePlayer* pPlayer)
 			continue; //At lesat one skill required by this title wasn't a top skill
 
 		//Is this the first valid title, or is this title better than the previous best title?
-		if (!pBestTitle ||												 //First valid title
-			(pBestTitle &&												 //Previous title exists
-				((Title.SkillsReq.size() > pBestTitle->SkillsReq.size()) || //This title is better because it requires more skills
-					(Title.MinLevel > pBestTitle->MinLevel))					 //This title is better because it requires a higher level
-				))
+
+		if (!pBestTitle) {
 			pBestTitle = &Title;
+		}
+		else if (Title.SkillsReq.size() > pBestTitle->SkillsReq.size()) {
+			pBestTitle = &Title;
+		}
+		else if (Title.MinLevel > pBestTitle->MinLevel) {
+			pBestTitle = &Title;
+		}
+
 	}
 
 	return pBestTitle;
@@ -166,14 +168,18 @@ title_t* CTitleManager::GetPlayerTitle(CBasePlayer* pPlayer)
 const char* CBasePlayer::GetTitle()
 {
 	//Lark DEC2017_16: Only replace old titles if CustomTitle is set.
-	if (!CustomTitle.contains("NONESET"))
-		return CustomTitle;
+	if (!CustomTitle.contains("NONESET") && CustomTitle)
+		return CustomTitle.c_str();
 	else
 	{
 		//Old Way
 		title_t* pTitle = CTitleManager::GetPlayerTitle(this);
-		if (pTitle) return pTitle->Name;
-		return "Unknown";
+		if (pTitle) {
+			return pTitle->Name.c_str();
+		}
+		else {
+			return CTitleManager::DefaultTitle.Name.c_str();
+		}
 	}
 }
 

--- a/src/game/shared/ms/scriptcmds.cpp
+++ b/src/game/shared/ms/scriptcmds.cpp
@@ -5020,38 +5020,42 @@ bool CScript::ScriptCmd_RegisterTexture(SCRIPT_EVENT &Event, scriptcmd_t &Cmd, m
 //- registers possible player titles based on weapon skills under the default title system
 bool CScript::ScriptCmd_RegisterTitle(SCRIPT_EVENT &Event, scriptcmd_t &Cmd, msstringlist &Params)
 {
-	if (Params.size() >= 1)
-	{
-		if (Params.size() < 2)
-		{	//Default title
-			CTitleManager::DefaultTitle.Name = Params[0];
-			CTitleManager::DefaultTitle.MinLevel = 0;
-		}
-		else
-		{	//Specific title
-			title_t NewTitle;
-			NewTitle.Name = Params[0];
-			NewTitle.MinLevel = atoi(GetScriptVar("TITLE_MINSKILL"));
-			static msstringlist Skills;
-			Skills.clearitems();
-			TokenizeString(Params[1], Skills);
-			bool SkillSuccess = true;
-			for(int s = 0; s < Skills.size(); s++)
-			{
-				int Skill = GetSkillStatByName(SCRIPTVAR(Skills[s]));
-				if (Skill == -1)
-				{
-					SkillSuccess = false;
-					break;
-				}
-				NewTitle.SkillsReq.add(Skill);
-			}
 
-			if (SkillSuccess)
-				CTitleManager::AddTitle(NewTitle);
-		}
+	if (Params.size() < 1) 
+	{
+		ERROR_MISSING_PARMS;
+		return false;
 	}
-	else ERROR_MISSING_PARMS;
+
+	if (Params.size() == 1)
+	{	//Default title
+		CTitleManager::DefaultTitle.Name = Params[0];
+		CTitleManager::DefaultTitle.MinLevel = 0;
+	}
+	else
+	{	//Specific title
+		title_t NewTitle;
+		NewTitle.Name = Params[0];
+		NewTitle.MinLevel = atoi(GetScriptVar("TITLE_MINSKILL"));
+		static msstringlist Skills;
+		Skills.clearitems();
+		TokenizeString(Params[1], Skills);
+		bool SkillSuccess = true;
+		int SKILL_FAILURE = -1;
+		for(int s = 0; s < Skills.size(); s++)
+		{
+			int Skill = GetSkillStatByName(SCRIPTVAR(Skills[s]));
+			if (Skill == SKILL_FAILURE)
+			{
+				SkillSuccess = false;
+				break;
+			}
+			NewTitle.SkillsReq.add(Skill);
+		}
+
+		if (SkillSuccess)
+			CTitleManager::AddTitle(NewTitle);
+	}
 
 	return true;
 }

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -788,13 +788,6 @@ void CGenericItem::StrikeLand()
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 
-	//Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
-	if (m_LastChargedAmt < 1)
-	{
-		flDamage *= (m_LastChargedAmt + 1);
-		//Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
-	}
-
 	SetDebugProgress(ItemThinkProgress, "CGenericItem::StrikeLand - Call DoDamage");
 	int bitsDamage = DMG_CLUB;
 	if (!m_pPlayer)

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -788,12 +788,11 @@ void CGenericItem::StrikeLand()
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 
-	Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
+	//Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
 	if (m_LastChargedAmt < 1)
 	{
 		flDamage *= (m_LastChargedAmt + 1);
-		Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
-
+		//Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
 	}
 
 	SetDebugProgress(ItemThinkProgress, "CGenericItem::StrikeLand - Call DoDamage");

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -776,48 +776,33 @@ void CGenericItem::StrikeLand()
 
 	float CurrentAttackBalance = m_pOwner->GetSkillStat(CurrentAttack->StatBalance, CurrentAttack->PropBalance);
 	float CurrentAttackPower = m_pOwner->GetSkillStat(CurrentAttack->StatPower, CurrentAttack->PropPower);
-	float flDmgFraction = 0.0f;
-	char sz[256] = "";
+	float flDamageFraction = 0.0f;
 
 	long randomMulti = RANDOM_LONG(0, CurrentAttack->flDamageRange);
 	float flDamage = CurrentAttack->flDamage + randomMulti; //fine even if 0.
 
-	//fraction based on balance. Balance stat for weapon -> 45? Multiplier is 0.45
-	flDmgFraction = CurrentAttackBalance / STATPROP_MAX_VALUE;
-	flDmgFraction = V_max(flDmgFraction, 0);
+	flDamageFraction = CurrentAttackBalance / STATPROP_MAX_VALUE;
+	flDamageFraction = V_max(flDamageFraction, 0);
 
 	std::string szDamage = std::to_string(flDamage);
 	std::string szBalance = std::to_string(CurrentAttackBalance);
-	std::string szFraction = std::to_string(flDmgFraction);
+	std::string szFraction = std::to_string(flDamageFraction);
 
-	UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Incoming Damage: %s", szDamage.c_str());
-	UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Balance: %s : Fraction : %s", szBalance.c_str(), szFraction.c_str());
+	//UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Incoming Damage: %s", szDamage.c_str());
+	//UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Balance: %s : Fraction : %s", szBalance.c_str(), szFraction.c_str());
 
 	//fraction based on balance. Power stat for weapon -> 45? Multiplier is 0.45
-	flDmgFraction = CurrentAttackPower / STATPROP_MAX_VALUE;
-	flDmgFraction = V_max(flDmgFraction, 0.001f);
+	flDamageFraction = CurrentAttackPower / STATPROP_MAX_VALUE;
+	flDamageFraction = V_max(flDamageFraction, 0.001f); //why is this 0.001f?
 
 	std::string szPower = std::to_string(CurrentAttackPower);
-	szFraction = std::to_string(flDmgFraction);
+	szFraction = std::to_string(flDamageFraction);
 
-	UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Power: %s : Fraction: %s", szPower.c_str(), szFraction.c_str());
-
-	//why is one zero and on 0.001f.
-	//minimum should be current weapons minimum level requirement.
-	//unless this is supposed to also prevent damage from wapons if not enough proficiency.
-	//in which cas that damage remove for non-proficiency shouild be a separate check.
-	//in the above event if the GetSkillStat() function fails, damage will be essentially be nulled.
-	//applying a minimum would atleast allow the damage of the strike through
-	//but would essentially be 'the worst hit poosible'
-
-
-
-	
+	//UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Power: %s : Fraction: %s", szPower.c_str(), szFraction.c_str());	
 
 	//	flDmgFraction = max(mSStat( CurrentAttack->sAttackStat, STATPROP_POWER ) / STATPROP_MAX_VALUE,0);
 	//	ALERT( at_console, "Use stat: %i  Value: %i %i %i\n", GetStatByName( (char*)STRING(CurrentAttack->sAttackStat) ), mSStat( CurrentAttack->sAttackStat, STATPROP_SPEED ), mSStat( CurrentAttack->sAttackStat, STATPROP_BALANCE ), mSStat( CurrentAttack->sAttackStat, STATPROP_POWER ) );
-	
-	
+	// 	
 
 	flDamage *= flDmgFraction;
 	if (bUnderleveled)

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -753,9 +753,6 @@ void CGenericItem::StrikeLand()
 
 	Vector vecEnd = vecSrc + vForward * CurrentAttack->flRange;
 
-	float flDmgFraction = m_pOwner->GetSkillStat(CurrentAttack->StatBalance, CurrentAttack->PropBalance) / STATPROP_MAX_VALUE;
-	flDmgFraction = V_max(flDmgFraction, 0);
-
 	//Thothie SEP2007 - attempting to make level limit work by decreasing accuracy
 	bool bUnderleveled = false;
 	if (m_pOwner->GetSkillStat(CurrentAttack->StatProf, CurrentAttack->PropProf) < CurrentAttack->RequiredSkill)
@@ -777,13 +774,51 @@ void CGenericItem::StrikeLand()
 	if (m_pOwner->m_HITMulti > 0)
 		flHitPercentage *= m_pOwner->m_HITMulti; //FEB2009_18
 
-	flDmgFraction = m_pOwner->GetSkillStat(CurrentAttack->StatPower, CurrentAttack->PropPower) / STATPROP_MAX_VALUE;
+	float CurrentAttackBalance = m_pOwner->GetSkillStat(CurrentAttack->StatBalance, CurrentAttack->PropBalance);
+	float CurrentAttackPower = m_pOwner->GetSkillStat(CurrentAttack->StatPower, CurrentAttack->PropPower);
+	float flDmgFraction = 0.0f;
+	char sz[256] = "";
+
+	long randomMulti = RANDOM_LONG(0, CurrentAttack->flDamageRange);
+	float flDamage = CurrentAttack->flDamage + randomMulti; //fine even if 0.
+
+	//fraction based on balance. Balance stat for weapon -> 45? Multiplier is 0.45
+	flDmgFraction = CurrentAttackBalance / STATPROP_MAX_VALUE;
+	flDmgFraction = V_max(flDmgFraction, 0);
+
+	std::string szDamage = std::to_string(flDamage);
+	std::string szBalance = std::to_string(CurrentAttackBalance);
+	std::string szFraction = std::to_string(flDmgFraction);
+
+	UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Incoming Damage: %s", szDamage.c_str());
+	UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Balance: %s : Fraction : %s", szBalance.c_str(), szFraction.c_str());
+
+	//fraction based on balance. Power stat for weapon -> 45? Multiplier is 0.45
+	flDmgFraction = CurrentAttackPower / STATPROP_MAX_VALUE;
 	flDmgFraction = V_max(flDmgFraction, 0.001f);
+
+	std::string szPower = std::to_string(CurrentAttackPower);
+	szFraction = std::to_string(flDmgFraction);
+
+	UTIL_ClientPrintAll(HUD_PRINTCONSOLE, "Power: %s : Fraction: %s", szPower.c_str(), szFraction.c_str());
+
+	//why is one zero and on 0.001f.
+	//minimum should be current weapons minimum level requirement.
+	//unless this is supposed to also prevent damage from wapons if not enough proficiency.
+	//in which cas that damage remove for non-proficiency shouild be a separate check.
+	//in the above event if the GetSkillStat() function fails, damage will be essentially be nulled.
+	//applying a minimum would atleast allow the damage of the strike through
+	//but would essentially be 'the worst hit poosible'
+
+
+
+	
 
 	//	flDmgFraction = max(mSStat( CurrentAttack->sAttackStat, STATPROP_POWER ) / STATPROP_MAX_VALUE,0);
 	//	ALERT( at_console, "Use stat: %i  Value: %i %i %i\n", GetStatByName( (char*)STRING(CurrentAttack->sAttackStat) ), mSStat( CurrentAttack->sAttackStat, STATPROP_SPEED ), mSStat( CurrentAttack->sAttackStat, STATPROP_BALANCE ), mSStat( CurrentAttack->sAttackStat, STATPROP_POWER ) );
-	long randomMulti = RANDOM_LONG(0, CurrentAttack->flDamageRange);
-	float flDamage = CurrentAttack->flDamage + randomMulti;
+	
+	
+
 	flDamage *= flDmgFraction;
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -788,11 +788,12 @@ void CGenericItem::StrikeLand()
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 
-	//Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
-	if (m_LastChargedAmt > 0 && m_LastChargedAmt < 1)
+	Print( "In damage: %f\nLast charged: %f\n", flDamage, m_LastChargedAmt );
+	if (m_LastChargedAmt < 1)
 	{
-		Print("Out damage: %f\n", flDamage *= m_LastChargedAmt);
-		flDamage *= m_LastChargedAmt;
+		flDamage *= (m_LastChargedAmt + 1);
+		Print("Out damage: %f\nCharge Multiplier: %f\n", flDamage, (m_LastChargedAmt+1));
+
 	}
 
 	SetDebugProgress(ItemThinkProgress, "CGenericItem::StrikeLand - Call DoDamage");

--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -804,7 +804,7 @@ void CGenericItem::StrikeLand()
 	//	ALERT( at_console, "Use stat: %i  Value: %i %i %i\n", GetStatByName( (char*)STRING(CurrentAttack->sAttackStat) ), mSStat( CurrentAttack->sAttackStat, STATPROP_SPEED ), mSStat( CurrentAttack->sAttackStat, STATPROP_BALANCE ), mSStat( CurrentAttack->sAttackStat, STATPROP_POWER ) );
 	// 	
 
-	flDamage *= flDmgFraction;
+	flDamage *= flDamageFraction;
 	if (bUnderleveled)
 		flDamage *= 0.5; //this might be working
 


### PR DESCRIPTION
The logic for (!CustomTitle.contains("NONESET")) was hitting the return statement despite CustomTitle being null in my testing.
Added && guard to check if CustomTitle is not null.

Removed some unneeded nesting.
Cleaned up a few comparison statements when determining best title.

Fixed comparison blocks during ScriptCmd_RegisterTitle to be more intuitive and ensured function returned false on failure.

Added some code refactor and variable renames to StrikeLand() and some commented statements in working to continue to isolate issue #346 root cause if not yet resolved.
