### PR TITLE
Fix crash from weapons dropped from monsters

### DIFF
--- a/src/game/shared/weapons/giattack.cpp
+++ b/src/game/shared/weapons/giattack.cpp
@@ -187,7 +187,7 @@ bool CGenericItem::Attack_CanAttack()
 {
 	if (!m_Attacks.size())
 		return false; //Must have registered an attack
-	if (!m_pOwner || !m_pOwner->IsAlive())
+	if (!m_pOwner || !m_pPlayer || !m_pOwner->IsAlive())
 		return false; //Owner must be alive
 	if (m_Location != ITEMPOS_HANDS)
 		return false; //Must be in owner's hands


### PR DESCRIPTION
Fixes calruin2 crash.
Weapon would try to reference calrian's despawned corpse, referencing memory that didn't belong to it.